### PR TITLE
Force 'strict' safety mode when calling Cohere models

### DIFF
--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -100,6 +100,9 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
 
       // messages:
       messages: chatPrompt,
+
+      // force 'strict' safety mode to enforce stricter model guidelines in the prompt
+      safety_mode: 'strict'
     };
 
     switch (type) {


### PR DESCRIPTION
The cohere API offers a `safety_mode` parameter which controls the safety instructions in the prompt. The default mode ('contextual') uses a less restrictive prompt. This PR changes the cohere model provider to always use 'strict' as the safety mode, forcing instructions that prompt the model to refuse to generate certain types of content.

Learn more about safety modes here: https://docs.cohere.com/docs/safety-modes